### PR TITLE
Add username/password parameters to support Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,16 @@ gitopscli deploy \
 --branch deployment-xyz \
 --values "{a.c: foo, a.b: '1'}" 
 ```
-or with `docker run`
+### Basic Auth
+To use Basic Auth when HTTP(S) is used, simply add the arguments
+```bash
+gitopscli deploy \
+[...]
+--username $GIT_USERNAME
+--password $GIT_PASSWORD
+```
+
+### Usage with Docker
 ```bash
 docker run --rm -it gitopscli deploy \
 --repo git@github.com:ora/repo.git \

--- a/gitopscli/__main__.py
+++ b/gitopscli/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 import uuid
+import shutil
 from .git_util import GitUtil
 from .yaml_util import yaml_load, update_yaml_file
 
@@ -17,6 +18,8 @@ def main():
         "-v", "--values", help="YAML string with key-value pairs to write", type=yaml_load, required=True,
     )
     deploy_p.add_argument("-b", "--branch", help="the branch to create (default: random UUID)")
+    deploy_p.add_argument("-u", "--username", help="Git username if Basic Auth should be used")
+    deploy_p.add_argument("-p", "--password", help="Git password if Basic Auth should be used")
 
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
@@ -25,14 +28,16 @@ def main():
     args = parser.parse_args()
 
     if args.command == "deploy":
-        deploy(args.repo, args.file, args.values, args.branch)
+        deploy(args.repo, args.file, args.values, args.branch, args.username, args.password)
 
 
-def deploy(repo, file_path, values, branch_name):
+def deploy(repo, file_path, values, branch_name, username, password):
+    tmp_dir = f"/tmp/gitopscli/{uuid.uuid4()}"
     if not branch_name:
         branch_name = str(uuid.uuid4())
 
-    git = GitUtil(repo, branch_name)
+    git = GitUtil(repo, branch_name, tmp_dir, username, password)
+
     full_file_path = git.get_full_file_path(file_path)
 
     for key in values:
@@ -41,6 +46,7 @@ def deploy(repo, file_path, values, branch_name):
         git.commit(f"changed '{key}' to '{value}'")
 
     git.push()
+    shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/gitopscli/git_util.py
+++ b/gitopscli/git_util.py
@@ -5,12 +5,14 @@ from pathlib import Path
 
 
 class GitUtil:
-    def __init__(self, repo, branch_name):
-        tmp_dir = "/tmp/gitopscli"
+    def __init__(self, repo, branch_name, tmp_dir, username = None, password = None):
         shutil.rmtree(tmp_dir, ignore_errors=True)
         os.makedirs(tmp_dir)
-
-        self._repo = Repo.clone_from(repo, tmp_dir)
+        git_options = []
+        if username is not None and password is not None:
+            credentials_file = self.create_credentials_file(tmp_dir, username, password)
+            git_options.append(f"--config credential.helper={credentials_file.name}")
+        self._repo = Repo.clone_from(url=repo, to_path=tmp_dir + "/" + branch_name, multi_options=git_options)
         self._repo.create_head(branch_name).checkout()
 
         self._branch_name = branch_name
@@ -27,3 +29,15 @@ class GitUtil:
 
     def push(self):
         self._repo.git.push("origin", self._branch_name)
+
+    def create_credentials_file(self, tmp_dir, username, password):
+        credentials_file = f"""#!/bin/bash
+echo username={username}
+echo password={password}
+    """
+        text_file = open(f"{tmp_dir}/credentials.sh", "w+")
+        text_file.write(credentials_file)
+        text_file.close()
+        os.chmod(text_file.name, 0o700)
+        return text_file
+


### PR DESCRIPTION
As GitPython doesn't directly support Basic Auth, it could be implemented by adding the repository URL using the following pattern:

```
--repo https://$GIT_USER:$GIT_PASSWORD@gitserver.tld/repo.git
```
The downside is that the URL appears in Exceptions which would lead to exposing the password.

Alternatively, a credential helper could be provided with the corresponding password as file. This approach is implemented with this PR. The credentials are passed with `--username` and `--password`