### PR TITLE
Add Github support

### DIFF
--- a/gitopscli/__main__.py
+++ b/gitopscli/__main__.py
@@ -5,6 +5,7 @@ import shutil
 import json
 import os
 from .bitbucket_git_util import BitBucketGitUtil
+from .github_git_util import GithubGitUtil
 from .yaml_util import yaml_load, update_yaml_file
 
 
@@ -65,23 +66,23 @@ def add_deploy_parser(subparsers):
     )
     deploy_p.add_argument("-s", "--git-provider", help="Git server provider", default="bitbucket-server")
     deploy_p.add_argument(
-        "-w", "--git-provider-url", help="Git provider base API URL (e.g. https://bitbucket.example.tld)", required=True
+        "-w", "--git-provider-url", help="Git provider base API URL (e.g. https://bitbucket.example.tld)"
     )
 
 
 def deploy(
-        command,
-        file,
-        values,
-        branch,
-        username,
-        password,
-        create_pr,
-        auto_merge,
-        organisation,
-        repository_name,
-        git_provider,
-        git_provider_url,
+    command,
+    file,
+    values,
+    branch,
+    username,
+    password,
+    create_pr,
+    auto_merge,
+    organisation,
+    repository_name,
+    git_provider,
+    git_provider_url,
 ):
     assert command == "deploy"
 
@@ -90,7 +91,12 @@ def deploy(
 
     try:
         if git_provider == "bitbucket-server":
+            if not git_provider_url:
+                print(f"Please provide --git-provider-url for bitbucket-server", file=sys.stderr)
+                sys.exit(1)
             git = BitBucketGitUtil(tmp_dir, git_provider_url, organisation, repository_name, username, password)
+        elif git_provider == "github":
+            git = GithubGitUtil(tmp_dir, organisation, repository_name, username, password)
         else:
             print(f"Git provider '{git_provider}' is not supported.", file=sys.stderr)
             sys.exit(1)

--- a/gitopscli/github_git_util.py
+++ b/gitopscli/github_git_util.py
@@ -1,0 +1,32 @@
+import sys
+from github import Github, UnknownObjectException
+from .abstract_git_util import AbstractGitUtil
+
+
+class GithubGitUtil(AbstractGitUtil):
+    def __init__(self, tmp_dir, organisation, repository_name, username, password):
+        super().__init__(tmp_dir, username, password)
+        self._organisation = organisation
+        self._repository_name = repository_name
+        self._github = Github(self._username, self._password)
+
+    def get_clone_url(self):
+        try:
+            repo = self._github.get_repo(f"{self._organisation}/{self._repository_name}")
+        except UnknownObjectException:
+            print(
+                f"Repository '{self._organisation}/{self._repository_name}' does not exist.", file=sys.stderr,
+            )
+            sys.exit(1)
+        return repo.clone_url
+
+    def create_pull_request(self, from_branch, to_branch, title, description):
+        repo = self._github.get_repo(f"{self._organisation}/{self._repository_name}")
+        pull_request = repo.create_pull(title=title, body=description, head=from_branch, base=to_branch)
+        return pull_request
+
+    def get_pull_request_url(self, pull_request):
+        return pull_request.html_url
+
+    def merge_pull_request(self, pull_request):
+        pull_request.merge()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 GitPython==3.0.5
 ruamel.yaml==0.16.5
 atlassian-python-api==1.14.5
+PyGithub==1.45


### PR DESCRIPTION
We probably should also support token auth:
```
Hi @christiansiegel,

You recently used a password to access an endpoint through the GitHub API using PyGithub/Python. We will deprecate basic authentication using password to this endpoint soon:

https://api.github.com/repositories/235198591

We recommend using a personal access token (PAT) with the appropriate scope to access this endpoint instead. Visit https://github.com/settings/tokens for more information.

Thanks,
The GitHub Team
```