### PR TITLE
Add `--single-commit` flag to deploy cmd

### DIFF
--- a/doc/commands/deploy.md
+++ b/doc/commands/deploy.md
@@ -2,10 +2,10 @@
 
 # deploy
 ```
-usage: gitopscli deploy [-h] -f FILE -v VALUES [-b BRANCH] [-u USERNAME]
-                        [-p PASSWORD] [-j GIT_USER] [-e GIT_EMAIL]
-                        [-c [CREATE_PR]] [-a [AUTO_MERGE]] -o ORGANISATION -n
-                        REPOSITORY_NAME [-s GIT_PROVIDER]
+usage: gitopscli deploy [-h] -f FILE -v VALUES [-g [SINGLE_COMMIT]]
+                        [-b BRANCH] [-u USERNAME] [-p PASSWORD] [-j GIT_USER]
+                        [-e GIT_EMAIL] [-c [CREATE_PR]] [-a [AUTO_MERGE]] -o
+                        ORGANISATION -n REPOSITORY_NAME [-s GIT_PROVIDER]
                         [-w GIT_PROVIDER_URL]
 
 optional arguments:
@@ -14,6 +14,8 @@ optional arguments:
   -v VALUES, --values VALUES
                         YAML/JSON object with the YAML path as key and the
                         desired value as value
+  -g [SINGLE_COMMIT], --single-commit [SINGLE_COMMIT]
+                        Create only single commit for all updates
   -b BRANCH, --branch BRANCH
                         Branch to push the changes to
   -u USERNAME, --username USERNAME

--- a/gitopscli/cliparser.py
+++ b/gitopscli/cliparser.py
@@ -33,6 +33,15 @@ def __add_deploy_command_parser(subparsers):
         type=yaml_load,
         required=True,
     )
+    deploy_p.add_argument(
+        "-g",
+        "--single-commit",
+        help="Create only single commit for all updates",
+        type=__str2bool,
+        nargs="?",
+        const=True,
+        default=False,
+    )
 
     __add_git_parser_args(deploy_p)
 

--- a/gitopscli/commands/deploy.py
+++ b/gitopscli/commands/deploy.py
@@ -46,18 +46,18 @@ def deploy_command(
         git.new_branch(branch)
         logging.info("Created branch %s", branch)
         full_file_path = git.get_full_file_path(file)
-        updated_any_value = False
+        updated_values = {}
         for key in values:
             value = values[key]
             if not update_yaml_file(full_file_path, key, value):
                 logging.info("Yaml property %s already up-to-date", key)
                 continue
             logging.info("Updated yaml property %s to %s", key, value)
-            updated_any_value = True
+            updated_values[key] = value
 
             git.commit(f"changed '{key}' to '{value}'")
 
-        if not updated_any_value:
+        if not updated_values:
             logging.info("All values already up-to-date. I'm done here")
             return
 
@@ -73,7 +73,7 @@ This Pull Request is automatically created through [gitopscli](https://github.co
 Files changed: `{file}`
 Values changed:
 ```yaml
-{yaml_dump(values)}
+{yaml_dump(updated_values)}
 """
         pull_request = git.create_pull_request(branch, "master", title, description)
         logging.info("Pull request created: %s", {git.get_pull_request_url(pull_request)})

--- a/gitopscli/commands/deploy.py
+++ b/gitopscli/commands/deploy.py
@@ -1,11 +1,10 @@
-import json
 import logging
 import os
 import shutil
 import uuid
 
 from gitopscli.git.create_git import create_git
-from gitopscli.yaml.yaml_util import update_yaml_file
+from gitopscli.yaml.yaml_util import update_yaml_file, yaml_dump
 
 
 def deploy_command(
@@ -73,9 +72,8 @@ def deploy_command(
 This Pull Request is automatically created through [gitopscli](https://github.com/baloise-incubator/gitopscli).
 Files changed: `{file}`
 Values changed:
-```json
-{json.dumps(values)}
-```
+```yaml
+{yaml_dump(values)}
 """
         pull_request = git.create_pull_request(branch, "master", title, description)
         logging.info("Pull request created: %s", {git.get_pull_request_url(pull_request)})

--- a/gitopscli/commands/deploy.py
+++ b/gitopscli/commands/deploy.py
@@ -68,12 +68,11 @@ def deploy_command(
 
     if create_pr and branch != "master":
         title = f"Updated values in {file}"
-        description = f"""
-This Pull Request is automatically created through [gitopscli](https://github.com/baloise-incubator/gitopscli).
-Files changed: `{file}`
-Values changed:
+        description = f"""\
+Updated values in `{file}`:
 ```yaml
 {yaml_dump(updated_values)}
+```
 """
         pull_request = git.create_pull_request(branch, "master", title, description)
         logging.info("Pull request created: %s", {git.get_pull_request_url(pull_request)})

--- a/gitopscli/yaml/yaml_util.py
+++ b/gitopscli/yaml/yaml_util.py
@@ -5,6 +5,21 @@ def yaml_load(doc):
     return YAML().load(doc)
 
 
+def yaml_dump(data):
+    class FakeStream:
+        _byte_strings = []
+
+        def write(self, byte_string):
+            self._byte_strings.append(byte_string)
+
+        def get_string(self):
+            return b"".join(self._byte_strings).decode("utf-8").rstrip()
+
+    stream = FakeStream()
+    YAML().dump(data, stream)
+    return stream.get_string()
+
+
 def update_yaml_file(file_path, key, value):
     yaml = YAML()
     with open(file_path, "r") as stream:

--- a/tests/test_yaml_util.py
+++ b/tests/test_yaml_util.py
@@ -3,7 +3,7 @@ import shutil
 import unittest
 import uuid
 
-from gitopscli.yaml.yaml_util import yaml_load, update_yaml_file, merge_yaml_element
+from gitopscli.yaml.yaml_util import yaml_load, yaml_dump, update_yaml_file, merge_yaml_element
 
 
 class YamlUtilTest(unittest.TestCase):
@@ -29,6 +29,19 @@ class YamlUtilTest(unittest.TestCase):
     def test_yaml_load(self):
         self.assertEqual(yaml_load("{answer: '42'}"), {"answer": "42"})
         self.assertEqual(yaml_load("{answer: 42}"), {"answer": 42})
+        self.assertEqual(yaml_load("answer: 42"), {"answer": 42})
+
+    def test_yaml_dump(self):
+        self.assertEqual(yaml_dump({"answer": "42"}), "answer: '42'")
+        self.assertEqual(yaml_dump({"answer": 42}), "answer: 42")
+        self.assertEqual(
+            yaml_dump({"answer": "42", "universe": ["and", "everything"]}),
+            """\
+answer: '42'
+universe:
+- and
+- everything""",
+        )
 
     def test_update_yaml_file(self):
         test_file = self._create_file(


### PR DESCRIPTION
- display updated values as YAML instead of JSON in PR
- display only *updated* values in PR
- shorten deploy PR message
- add `--single-commit` flag to deploy cmd
