### PR TITLE
Add short getting started doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ venv/
 testrepo/
 .idea
 *.iml
+.eggs/
 site/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,2 @@
 tasks:
-  - init: make install && gitopscli --help
+  - init: make init && gitopscli --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,28 +3,21 @@ FROM python:3.7-alpine AS base-image
 ENV PATH="/opt/venv/bin:$PATH"
 RUN apk add --no-cache git
 
-FROM base-image AS deps-image
+FROM base-image AS build-image
 
 RUN apk add --no-cache gcc linux-headers musl-dev \
  && python -m venv /opt/venv \
  && pip install --upgrade pip
 WORKDIR /workdir
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-FROM deps-image AS test-image
-
-COPY requirements-dev.txt .
-RUN pip install -r requirements-dev.txt
 COPY . .
+RUN pip install .
+
+FROM build-image AS test-image
+
+RUN pip install -r requirements-dev.txt
 RUN black --check -l 120 -t py37 gitopscli tests setup.py
 RUN pylint gitopscli
 RUN python -m pytest -v
-
-FROM deps-image AS build-image
-
-COPY . .
-RUN pip install .
 
 FROM base-image AS runtime-image
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+init:
+	pip3 install --editable .
+	pip3 install -r requirements-dev.txt
+
 format:
 	black -l 120 -t py37 gitopscli tests setup.py
 
@@ -7,18 +11,10 @@ lint:
 test:
 	python3 -m pytest -v -s
 
-install:
-	pip3 install -r requirements.txt
-	pip3 install -r requirements-dev.txt
-	pip3 install --editable .
-
-uninstall:
-	pip3 uninstall gitopscli
-
-build:
+image:
 	docker build -t gitopscli:latest .
 
 docs:
 	mkdocs serve
 
-.PHONY: format lint test install uninstall build docs
+.PHONY: init format lint test image docs

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The official GitOps CLI Docker image comes with all dependencies pre-installed a
 ```bash
 docker pull baloiseincubator/gitopscli
 ```
-Start the CLI and the print help page with:
+Start the CLI and the print the help page with:
 ```bash
 docker run --rm -it baloiseincubator/gitopscli --help
 ```

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ docker run --rm -it baloiseincubator/gitopscli --help
 
 ## Features
 - Update YAML values in config repository to e.g. deploy an application.
-- Add a pull request comments.
+- Add pull request comments.
 - Create and delete preview environments in the config repository for a pull request in an app repository.
-- Update root config repository with all apps from child config repository.
+- Update root config repository with all apps from child config repositories.
 
 For detailed installation and usage instructions, visit [https://baloise-incubator.github.io/gitopscli/](https://baloise-incubator.github.io/gitopscli/).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,25 @@
 # Getting started
 
-!!! warning "ToDo"
-    
+The GitOps CLI provides several commands which can be used to perform typical operations on GitOps managed infrastructure repositories. You can print a help page listing all available commands with `gitopscli --help`:
+
+```
+usage: gitopscli [-h]
+                 {deploy,sync-apps,add-pr-comment,create-preview,delete-preview}
+                 ...
+
+GitOps CLI
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+commands:
+  {deploy,sync-apps,add-pr-comment,create-preview,delete-preview}
+    deploy              Trigger a new deployment by changing YAML values
+    sync-apps           Synchronize applications (= every directory) from apps
+                        config repository to apps root config
+    add-pr-comment      Create a comment on the pull request
+    create-preview      Create a preview environment
+    delete-preview      Delete a preview environment
+```
+
+A detailed description of the individual commands including some examples can be found in the [CLI Commands](/commands/add-pr-comment/) section.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,6 @@ A command line interface to perform operations on GitOps managed infrastructure 
 
 ## Features
 - Update YAML values in config repository to e.g. deploy an application
-- Add a pull request comments
+- Add pull request comments
 - Create and delete preview environments in the config repository for a pull request in an app repository
-- Update root config repository with all apps from child config repository
+- Update root config repository with all apps from child config repositories

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,30 @@
+# Setup
+
+Currently there are two different ways to setup and use the GitOps CLI.
+
+## Docker
+
+The official GitOps CLI Docker image comes with all dependencies pre-installed and ready-to-use. Pull it with:
+```bash
+docker pull baloiseincubator/gitopscli
+```
+Start the CLI and the print the help page with:
+```bash
+docker run --rm -it baloiseincubator/gitopscli --help
+```
+
+## From Source
+
+Clone the repository and install the GitOps CLI on your machine:
+```bash
+git clone https://github.com/baloise-incubator/gitopscli.git
+pip3 install gitopscli/
+```
+You can now use it from the command line:
+```bash
+gitopscli --help
+```
+If you don't need the CLI anymore, you can uninstall it with
+```bash
+pip3 uninstall gitopscli
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ repo_url: 'https://github.com/baloise-incubator/gitopscli'
 # Navigation
 nav:
   - Home: index.md
+  - Setup: setup.md
   - Getting started: getting-started.md
   - CLI Commands:
     - add-pr-comment: commands/add-pr-comment.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-GitPython==3.0.5
-ruamel.yaml==0.16.5
-atlassian-python-api==1.14.5
-PyGithub==1.45

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,6 @@ setup(
     version="2.1.0",
     packages=find_packages(),
     entry_points={"console_scripts": ["gitopscli = gitopscli.__main__:main"]},
+    setup_requires=["wheel"],
+    install_requires=["GitPython==3.0.6", "ruamel.yaml==0.16.5", "atlassian-python-api==1.14.5", "PyGithub==1.45",],
 )


### PR DESCRIPTION
- add short setup and getting started guide
- move requirements to setup.py to allow full installation from source with only `pip3 install .`

Resolves #58 