### PR TITLE
Remove --branch arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The `--branch` arg of the `delete-preview` command now only refers to the app repo branch. The config repo changes are pushed to `master` by default or to a randomly created branch name if `--create_pr` is given.
+
+### Removed
+- The `--branch` arg was removed for commands `deploy` and `create-preview`. For `create-preview` the app repo branch is detected via the `--pr_id`. All changes in the config repo are pushed to `master` by default, or to a randomly created branch name if `--create_pr` is given.
 
 ## [2.1.0] - 2020-02-09
 ### Added

--- a/docs/commands/create-preview.md
+++ b/docs/commands/create-preview.md
@@ -70,12 +70,9 @@ gitopscli create-preview \
   --organisation "my-team" \
   --repository-name "app-xy" \
   --pr-id 4711 \
-  --branch "my-pr-branch" \
   --create-pr \
   --auto-merge
 ```
-
-!!! warning "The `--branch` parameter is currently used to locate the PR branch in the *app repository* as well as to create the change branch in the *deployment config repository*. This may lead to branch collisions in the config repository. Hence, the current behavior may be subject to change in the near future. [(Issue #40)](https://github.com/baloise-incubator/gitopscli/issues/40)"
 
 ## Usage
 ```
@@ -84,7 +81,7 @@ usage: gitopscli create-preview [-h] --username USERNAME --password PASSWORD
                                 --organisation ORGANISATION --repository-name
                                 REPOSITORY_NAME [--git-provider GIT_PROVIDER]
                                 [--git-provider-url GIT_PROVIDER_URL]
-                                [--branch BRANCH] [--create-pr [CREATE_PR]]
+                                [--create-pr [CREATE_PR]]
                                 [--auto-merge [AUTO_MERGE]] --pr-id PR_ID
                                 [--parent-id PARENT_ID] [-v [VERBOSE]]
 
@@ -104,10 +101,8 @@ optional arguments:
   --git-provider-url GIT_PROVIDER_URL
                         Git provider base API URL (e.g.
                         https://bitbucket.example.tld)
-  --branch BRANCH       Branch to push the changes to
   --create-pr [CREATE_PR]
-                        Creates a Pull Request (only when --branch is not
-                        master/default branch)
+                        Creates a Pull Request
   --auto-merge [AUTO_MERGE]
                         Automatically merge the created PR (only valid with
                         --create-pr)

--- a/docs/commands/delete-preview.md
+++ b/docs/commands/delete-preview.md
@@ -24,8 +24,8 @@ usage: gitopscli delete-preview [-h] --username USERNAME --password PASSWORD
                                 [--git-user GIT_USER] [--git-email GIT_EMAIL]
                                 --organisation ORGANISATION --repository-name
                                 REPOSITORY_NAME [--git-provider GIT_PROVIDER]
-                                [--git-provider-url GIT_PROVIDER_URL]
-                                [--branch BRANCH] [--create-pr [CREATE_PR]]
+                                [--git-provider-url GIT_PROVIDER_URL] --branch
+                                BRANCH [--create-pr [CREATE_PR]]
                                 [--auto-merge [AUTO_MERGE]] [-v [VERBOSE]]
 
 optional arguments:
@@ -44,10 +44,9 @@ optional arguments:
   --git-provider-url GIT_PROVIDER_URL
                         Git provider base API URL (e.g.
                         https://bitbucket.example.tld)
-  --branch BRANCH       Branch to push the changes to
+  --branch BRANCH       The branch for which the preview was created for
   --create-pr [CREATE_PR]
-                        Creates a Pull Request (only when --branch is not
-                        master/default branch)
+                        Creates a Pull Request
   --auto-merge [AUTO_MERGE]
                         Automatically merge the created PR (only valid with
                         --create-pr)

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -27,8 +27,7 @@ gitopscli deploy \
   --organisation "deployment" \
   --repository-name "incubator-non-prod" \
   --file "example/values.yaml" \
-  --values "{frontend.tag: 1.1.0, backend.tag: 1.1.0}" \
-  --branch "master"
+  --values "{frontend.tag: 1.1.0, backend.tag: 1.1.0}"
 ```
 
 ### Number Of Commits
@@ -66,8 +65,6 @@ Date:   Thu Mar 12 15:30:00 2020 +0100
 
 In some cases you might want to create a pull request for your updates. You can achieve this by adding `--create-pr` to the command. The pull request can be left open or merged directly with `--auto-merge`.
 
-!!! info "We recommend creating a random branch name for automatically created pull requests to prevent collisions."
-
 ```bash
 gitopscli deploy \
   --git-provider-url https://bitbucket.baloise.dev \
@@ -79,7 +76,6 @@ gitopscli deploy \
   --repository-name "incubator-non-prod" \
   --file "example/values.yaml" \
   --values "{frontend.tag: 1.1.0, backend.tag: 1.1.0}" \
-  --branch deploy-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 5 | head -n 1) \
   --create-pr \
   --auto-merge
 ```
@@ -98,8 +94,8 @@ usage: gitopscli deploy [-h] --file FILE --values VALUES
                         --repository-name REPOSITORY_NAME
                         [--git-provider GIT_PROVIDER]
                         [--git-provider-url GIT_PROVIDER_URL]
-                        [--branch BRANCH] [--create-pr [CREATE_PR]]
-                        [--auto-merge [AUTO_MERGE]] [-v [VERBOSE]]
+                        [--create-pr [CREATE_PR]] [--auto-merge [AUTO_MERGE]]
+                        [-v [VERBOSE]]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -122,10 +118,8 @@ optional arguments:
   --git-provider-url GIT_PROVIDER_URL
                         Git provider base API URL (e.g.
                         https://bitbucket.example.tld)
-  --branch BRANCH       Branch to push the changes to
   --create-pr [CREATE_PR]
-                        Creates a Pull Request (only when --branch is not
-                        master/default branch)
+                        Creates a Pull Request
   --auto-merge [AUTO_MERGE]
                         Automatically merge the created PR (only valid with
                         --create-pr)

--- a/gitopscli/cliparser.py
+++ b/gitopscli/cliparser.py
@@ -76,6 +76,9 @@ def __add_create_preview_command_parser(subparsers):
 def __add_delete_preview_command_parser(subparsers):
     add_delete_preview_p = subparsers.add_parser("delete-preview", help="Delete a preview environment")
     __add_git_parser_args(add_delete_preview_p)
+    add_delete_preview_p.add_argument(
+        "--branch", help="The branch for which the preview was created for", required=True
+    )
     __add_branch_pr_parser_args(add_delete_preview_p)
     __add_verbose_parser(add_delete_preview_p)
 
@@ -93,14 +96,8 @@ def __add_git_parser_args(deploy_p, api_only=False):
 
 
 def __add_branch_pr_parser_args(deploy_p):
-    deploy_p.add_argument("--branch", help="Branch to push the changes to", default="master")
     deploy_p.add_argument(
-        "--create-pr",
-        help="Creates a Pull Request (only when --branch is not master/default branch)",
-        type=__str2bool,
-        nargs="?",
-        const=True,
-        default=False,
+        "--create-pr", help="Creates a Pull Request", type=__str2bool, nargs="?", const=True, default=False,
     )
     deploy_p.add_argument(
         "--auto-merge",

--- a/gitopscli/commands/deploy.py
+++ b/gitopscli/commands/deploy.py
@@ -12,7 +12,6 @@ def deploy_command(
     command,
     file,
     values,
-    branch,
     username,
     password,
     git_user,
@@ -46,22 +45,24 @@ def deploy_command(
         git.checkout("master")
         logging.info("Master checkout successful")
 
-        if branch != "master":
-            git.new_branch(branch)
-            logging.info("Created branch %s", branch)
+        config_branch = f"gitopscli-deploy-{str(uuid.uuid4())[:8]}" if create_pr else "master"
+
+        if create_pr:
+            git.new_branch(config_branch)
+            logging.info("Created branch %s", config_branch)
 
         updated_values = __update_values(git, file, values, single_commit)
         if not updated_values:
             logging.info("All values already up-to-date. I'm done here")
             return
 
-        git.push(branch)
-        logging.info("Pushed branch %s", branch)
+        git.push(config_branch)
+        logging.info("Pushed branch %s", config_branch)
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
-    if create_pr and branch != "master":
-        __create_pr(git, branch, file, updated_values, auto_merge)
+    if create_pr:
+        __create_pr(git, config_branch, file, updated_values, auto_merge)
 
 
 def __update_values(git, file, values, single_commit):

--- a/gitopscli/git/abstract_git_util.py
+++ b/gitopscli/git/abstract_git_util.py
@@ -99,3 +99,7 @@ class AbstractGitUtil(ABC):
     @abstractmethod
     def delete_branch(self, branch):
         pass
+
+    @abstractmethod
+    def get_pull_request_branch(self, pr_id):
+        pass

--- a/gitopscli/git/bitbucket_git_util.py
+++ b/gitopscli/git/bitbucket_git_util.py
@@ -80,3 +80,9 @@ class BitBucketGitUtil(AbstractGitUtil):
         )
         if result and "errors" in result:
             raise GitOpsException(result["errors"][0]["message"])
+
+    def get_pull_request_branch(self, pr_id):
+        pull_request = self._bitbucket.get_pullrequest(self._organisation, self._repository_name, pr_id)
+        if "errors" in pull_request:
+            raise GitOpsException(pull_request["errors"][0]["message"])
+        return pull_request["fromRef"]["displayId"]

--- a/gitopscli/git/github_git_util.py
+++ b/gitopscli/git/github_git_util.py
@@ -26,11 +26,7 @@ class GithubGitUtil(AbstractGitUtil):
         pull_request.merge()
 
     def add_pull_request_comment(self, pr_id, text, parent_id=None):
-        repo = self.__get_repo()
-        try:
-            pull_request = repo.get_pull(pr_id)
-        except UnknownObjectException as ex:
-            raise GitOpsException(f"Pull request with ID '{pr_id}' does not exist.") from ex
+        pull_request = self.__get_pull_request(pr_id)
         pr_comment = pull_request.create_issue_comment(text)
         return pr_comment
 
@@ -41,6 +37,17 @@ class GithubGitUtil(AbstractGitUtil):
         except UnknownObjectException as ex:
             raise GitOpsException(f"Branch '{branch}' does not exist.") from ex
         git_ref.delete()
+
+    def get_pull_request_branch(self, pr_id):
+        pull_request = self.__get_pull_request(pr_id)
+        return pull_request.head.ref
+
+    def __get_pull_request(self, pr_id):
+        repo = self.__get_repo()
+        try:
+            return repo.get_pull(pr_id)
+        except UnknownObjectException as ex:
+            raise GitOpsException(f"Pull request with ID '{pr_id}' does not exist.") from ex
 
     def __get_repo(self):
         try:


### PR DESCRIPTION
Background:
The `--branch` arg was used to create the config PR branch _AND_ to
locate the PR branch in case of `create-preview` and `delete-preview`.
This is confusing for the user and can potentially lead to branch
collisions in the config repo.

Solution:
- Randomly create branch names for the config repo (if `--create_pr` is
  given) or directly push to the master branch.
- In case of `create-preview`, get the PR branch name through the API
  via `--pr_id`
- In case of `delete-preview` we still need to know the branch name. For
  this reason, this is the only command which still has the arg `--branch`.